### PR TITLE
Update to current CoC

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,258 +1,87 @@
-Code of Conduct for PDXGo
-=========================
+# Code of Conduct for PDXGo
 
-PDXGo shall adhere to the [offical Golang Code of Conduct proposal](https://github.com/golang/proposal/blob/master/design/13073-code-of-conduct.md) by [Andrew Gerrardi](https://github.com/adg).
+PDXGo shall adhere to the [offical Go Community Code of Conduct](https://golang.org/conduct).
 
-### About the Code of Conduct
+## About 
+Online communities include people from many different backgrounds. The Go contributors are committed to providing a friendly, safe and welcoming environment for all, regardless of gender identity and expression, sexual orientation, disabilities, neurodiversity, physical appearance, body size, ethnicity, nationality, race, age, religion, or similar personal characteristics.
 
-#### Why have one?
+The first goal of the Code of Conduct is to specify a baseline standard of behavior so that people with different social values and communication styles can talk about Go effectively, productively, and respectfully.
 
-Online communities include people from many different backgrounds. The first
-goal of the Code of Conduct (CoC) is to specify a baseline of common courtesy
-so that people with different social mores and communication styles can
-communicate with each other effectively, productively, and respectfully.
+The second goal is to provide a mechanism for resolving conflicts in the community when they arise.
 
-Another goal of the CoC is to make our community welcoming to people from
-different backgrounds. Diversity is critical to the project; for Go to become a
-success, it needs contributors and users from all backgrounds. (See Go, Open
-Source, Community.)
+The third goal of the Code of Conduct is to make our community welcoming to people from different backgrounds. Diversity is critical to the project; for Go to be successful, it needs contributors and users from all backgrounds. (See [Go, Open Source, Community.](https://blog.golang.org/open-source))
 
-To be explicit: the Go contributors are committed to providing a friendly, safe
-and welcoming environment for all, regardless of gender, sexual orientation,
-disability, ethnicity, religion, or similar personal characteristic.
+We believe that healthy debate and disagreement are essential to a healthy project and community. However, it is never ok to be disrespectful. We value diverse opinions, but we value respectful behavior more. 
 
-#### Where does it apply?
+## Gopher values
+These are the values to which people in the Go community (“Gophers”) should aspire.
 
-The Code of Conduct applies generally. If you participate in or contribute to
-the Go ecosystem in any way, you should observe the Code of Conduct.
+  * Be friendly and welcoming
+  * Be patient
+      * Remember that people have varying communication styles and that not everyone is using their native language. (Meaning and tone can be lost in translation.) 
+  * Be thoughtful
+    * Productive communication requires effort. Think about how your words will be interpreted.
+    * Remember that sometimes it is best to refrain entirely from commenting. 
+  * Be respectful
+    * In particular, respect differences of opinion. 
+  * Be charitable
+    * Interpret the arguments of others in good faith, do not seek to disagree.
+      When we do disagree, try to understand why. 
+  * Avoid destructive behavior:
+      * Derailing: stay on topic; if you want to talk about something else, start a new conversation.
+      * Unconstructive criticism: don't merely decry the current state of affairs; offer—or at least solicit—suggestions as to how things may be improved.
+      * Snarking (pithy, unproductive, sniping comments)
+      * Discussing potentially offensive or sensitive issues; this all too often leads to unnecessary conflict.
+      *  Microaggressions: brief and commonplace verbal, behavioral and environmental indignities that communicate hostile, derogatory or negative slights and insults to a person or group. 
 
-PDXGo will enforce this Code of Conduct at meetings and in online discussion forums.
+People are complicated. You should expect to be misunderstood and to misunderstand others; when this inevitably occurs, resist the urge to be defensive or assign blame. Try not to take offense where no offense was intended. Give people the benefit of the doubt. Even if the intent was to provoke, do not rise to it. It is the responsibility of all parties to de-escalate conflict when it arises. 
 
-Explicit enforcement of the Code of Conduct can only practically apply to the
-official forums operated by the Go project (the official Go GitHub projects, Go
-project code reviews, the #go-nuts IRC channel, the /r/golang sub-reddit, and
-the various golang-* mailing lists operated on Google Groups).
+# Code of Conduct
 
-Other Go groups (such as conferences, meetups, and other unofficial forums) are
-encouraged to use this Code of Conduct as well.
+## Our Pledge 
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
 
-Furthermore, if your conduct outside the Go community is against our values
-(below), it may affect your ability to participate within our community.
+## Our Standards
+Examples of behavior that contributes to creating a positive environment include:
 
-### Gopher values
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
 
-This section states the values to which Go enthusiasts (“Gophers”) should
-aspire, and the kinds of behaviors that are not acceptable in our community.
+Examples of unacceptable behavior by participants include:
 
-* Be friendly and welcoming
-* Be patient
-   * Remember that people have varying communication styles, and that not everyone speaks English fluently.
-* Be respectful
-   * In particular, respect differences of opinion.
-* Be charitable
-   * Interpret the arguments of others in good faith, do not seek to disagree.
-   * When we do disagree, try to understand why.
-* Be thoughtful
-   * Productive communication requires effort. Think about how your words will be interpreted.
-   * Remember that sometimes it is best to refrain from commenting entirely.
-* Avoid destructive behavior, for example:
-   * Snarking (pithy, unproductive, sniping comments)
-   * Derailing (try to stay on topic; if you want to talk about something else,
-     start a new conversation)
-   * Unconstructive criticism (don't merely decry the current state of affairs;
-     offer suggestions as to how things may be improved)
-   * Insulting, demeaning, hateful, oppressive, exclusionary, or otherwise
-     hurtful remarks.
-   * Romantic or sexual commentary, remarks, or questions.
-   * Harassment (either in public or private; if someone asks you to stop
-     speaking to/at them, you must stop immediately)
-   * Flirting with offensive or sensitive issues, particularly if they're
-     off-topic; this all too often leads to unnecessary conflict.
-   * “Microaggressions,” the small, subtle, often subconscious actions that
-     marginalize people in oppressed groups.
-* Don't just aim to be technically unimpeachable, aim to be your best self.
-   * If someone takes issue with something you said or did, resist the urge to
-     be defensive. Just stop doing what it was they complained about and
-     apologize.
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others’ private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
 
-### Enforcement
+## Our Responsibilities
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
 
-The official Go forums (as described in the “Where does it apply” section
-above) are not free speech venues. They are for structured conversation about
-Go.
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
 
-If you wish to conduct yourself in a way that goes against the values stated in
-the previous section, you will be asked to stop. If you do not stop, you will
-be removed from our community spaces.
+## Scope
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
 
-The forum moderators are volunteers that are free to act with their own
-discretion. Moderators are held to a higher standard than other community
-members. If a moderator creates an inappropriate situation, they should expect
-less leeway than others, and should expect to be removed for their position if
-they cannot adhere to the code. 
+This Code of Conduct also applies outside the project spaces when the Project Steward has a reasonable belief that an individual’s behavior may have a negative impact on the project or its community.
 
-Complaints about moderator actions must be dealt with in private
-(use the reporting process below).
+## Conflict Resolution
+We do not believe that all conflict is bad; healthy debate and disagreement often yield positive results. However, it is never okay to be disrespectful or to engage in behavior that violates the project’s code of conduct.
 
-### Reporting issues
+If you see someone violating the code of conduct, you are encouraged to address the behavior directly with those involved. Many issues can be resolved quickly and easily, and this gives people more control over the outcome of their dispute. If you are unable to resolve the matter for any reason, or if the behavior is threatening or harassing, report it. We are dedicated to providing an environment where participants feel welcome and safe.
 
-The Code of Conduct Working Group are a group of people that represent the Go community. They are responsible for handling code-related issues. They are:
+Reports should be directed to Cassandra Salisbury, the Go Project Steward, at conduct@golang.org. It is the Project Steward’s duty to receive and address reported violations of the code of conduct. They will then work with a committee consisting of representatives from the Open Source Programs Office and the Google Open Source Strategy team. If for any reason you are uncomfortable reaching out the Project Steward, please email the Google Open Source Programs Office at opensource@google.com.
 
-* Aditya Mukerjee <dev@chimeracoder.net>
-* Andrew Gerrand <adg@golang.org>
-* Dave Cheney <dave@cheney.net>
-* Jason Buberel <jbuberel@google.com>
-* Peggy Li <peggyli.224@gmail.com>
-* Sarah Adams <sadams.codes@gmail.com>
-* Steve Francia <steve.francia@gmail.com>
-* Verónica López <gveronicalg@gmail.com>
+We will investigate every complaint, but you may not receive a direct response. We will use our discretion in determining when and how to follow up on reported incidents, which may range from not taking action to permanent expulsion from the project and project-sponsored spaces. We will notify the accused of the report and provide them an opportunity to discuss it before any action is taken. The identity of the reporter will be omitted from the details of the report supplied to the accused. In potentially harmful situations, such as ongoing harassment or threats to anyone’s safety, we may take action without notice.
 
-For PDXGo CoC specific issues:
-* Josh Roppo <joshroppo@gmail.com>
+## Attribution
+This Code of Conduct is adapted from the Contributor Covenant, version 1.4, available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
 
-(Membership changes to the Community Working Group can be proposed via the
-[Go Change Proposal Process](https://golang.org/s/proposal-process).)
-
-If you encounter a Code of Conduct-related issue, you should report it to the
-Code of Conduct Working Group using the process described below. Do not post
-about the issue publicly or try to rally sentiment against a particular
-individual or group.
-
-* Mail conduct@golang.org or fill in [TODO(adg): anonymous web form]
-   * Your mail will reach the Go Code of Conduct Working Group.
-   * Reports are confidential within the working group.
-   * Note that if you choose to remain anonymous then you cannot be notified of
-     the outcome of your report.
-   * You may contact a member of the group directly if you do not feel
-     comfortable contacting the group as a whole. (You may receive a delayed
-     response in this case.)
-   * If your report concerns a member of the working group they will be recused
-     from working group discussions of the report.
-   * The working group will strive to handle reports with sensitivity, to
-     protect the privacy of the involved parties, and to avoid conflicts of
-     interest.
-* You will receive a response within 24-48 hours (likely sooner).
-* The group will meet to review the incident and determine what happened.
-   * With the permission of person reporting the incident, the group may reach
-     out to other community members for more context.
-* The group will reach a decision as to how to act. These include:
-   * Nothing.
-   * A request for a private or public apology.
-   * A private reprimand from the working group to the individual(s) involved.
-   * A public reprimand.
-   * An imposed vacation (for instance, asking someone to "take a week off"
-     from a mailing list or IRC).
-   * A permanent or temporary ban from some or all Go spaces (mailing lists,
-     IRC, etc.)
-* The group will reach out to the original reporter to let them know the
-  decision.
-* Appeals to the decision may be made to the working group, or to any of its
-  members directly.
-
-### Summary (tl;dr)
-
-* Treat everyone with respect and kindness
-* Be mindful of how your words may be interpreted
-* Don’t be destructive or antagonistic
-* If you have an issue, please mail conduct@golang.org
-
----
-
-## Rationale
-
-*Do we need a Code of Conduct?* Some community members have argued that people should be trusted to do the right thing, or simply ignored when they do not. To address the former: there are varying definitions of the “right thing”; a Code of Conduct specifies what that means. To address the latter: if we allow negative forms of communication to flourish, we will be left only with people who enjoy that kind of communication.
-
-*Why write our own?* There are many existing Codes of Conduct to choose from, so we could have saved some time by simply re-using an existing one. This document does draw heavily on existing documents such as the Rust and Django Codes of Conduct, but it includes some original material too. I opted for this approach to specifically address the needs of the Go community as I understand them.
-
-### Examples of CoC issues and their resolutions
-
-These fictional examples show how community members and the working group might
-use the Code of Conduct’s guidelines to resolve a variety of issues. In each
-case, the goal of the intervention is to raise the level of discourse and to
-make people feel welcome in our community spaces.
-
-Rude and unwelcoming behavior:
-
-* J and S are emailing back and forth on a golang-nuts thread.
-* D enters the conversation and proposes an alternative solution. 
-* J and S ignore D and continue their discussion.
-* D re-articulates their point in a different way.
-* J responds to D by asking them to "butt out".
-* S emails J privately, noting that J's reaction was uncalled-for, and suggests that J apologize to D.
-* J replies that they have nothing to apologize for.
-* S reports the incident to the CoC Working Group.
-* T, a member of the working group, contacts J and S separately to get details on the incident.
-* T asks J to apologize for being unwelcoming and exclusive, and notifies S that this action was taken.
-* J acknowledges their mistake and apologizes to D.
-* The issue is resolved.
-
-A classic troll:
-
-* Q repeatedly posts about a particular issue, raising the issue on unrelated threads, as well as starting many redundant threads.
-* The forum moderators warn Q to stop, as derailing threads and spamming are against the CoC.
-* Q refuses and becomes belligerent, making insulting remarks about the moderators and other members of the community.
-* The moderators ban Q from the forum, and post a message explaining this.
-* The issue is resolved.
-
-Condescending behavior:
-
-* M posts a message to /r/golang describing the approach they're planning to take for wrapping http.HandlerFunc and asking for feedback.
-* P replies to the message "Why don’t you just do it the obvious way?" with an explanation of an alternate approach. =
-* N, a bystander to this exchange, replies “That may have been obvious to you, but you shouldn’t assume that it’s obvious to just anyone.”
-* P replies “Well I guess you’re an idiot too, then.”
-* Q, a moderator, observes this interaction and sends a message to P to tell them their behavior is unacceptable.
-* P insists there is nothing wrong with their behavior.
-* Q bans P, and posts to the original thread “I have banned P because their behavior was unacceptable. Sorry for the trouble.”
-* The issue is resolved.
-
-Two examples of “microaggressions”:
-
-* J is a regular poster to the golang-nuts mailing list. On one thread, they make the comment “Go’s type system is so simple even my grandma could understand it.”
-* Another poster points out that the comment goes against the code of conduct, since it marginalises women and the elderly by implying that something need be simple for an old woman to understand it.
-* J says “Fair point. Sorry for saying that.”
-* The issue is resolved.
-
-
-* K has typically female name and posts to a mailing list to announce a Go-to-Forth compiler they wrote.
-* N replies “It’s impressive to see a woman doing such great work. Nice job!”
-* K writes to the CoC Working Group to say “I felt really deflated for my work to be seen as impressive just because I’m a woman. Can you say something to N for me?”
-* T, a member of the working group, reaches out to N to explain how their words affected K.
-* Recognizing the hurt N has caused, N sends an email to K to apologise.
-* The issue is resolved.
-
-## Compatibility
-
-Some people feel stifled by the general concept of a Code of Conduct. Others
-may find explicit efforts to improve diversity in our community unpalatable for
-various reasons. While a major goal of this proposal is to make the community
-more inclusive, this does by definition exclude people that cannot abide by the
-goals and principles of the code. I see this as a regrettable but necessary and
-inescapable design tradeoff. The implementation of the code may cause us to
-lose a few people, but we stand to gain much more.
-
-## Implementation
-
-I (Andrew Gerrand) will submit the Code of Conduct text to the main Go
-repository, so that it is available at the URL https://golang.org/conduct.
-I will also set up the conduct@golang.org email address and the anonymous web
-form. 
-
-Then I will link the document prominently from these places:
-
-* `README.md` and `CONTRIBUTING.md` files in the official Go repositories.
-* The golang-nuts and golang-dev mailing list welcome messages.
-* The #go-nuts IRC channel topic.
-* The /r/golang subreddit sidebar.
-
-I will work with the existing moderators of these spaces to implement the Code
-of Conduct in those spaces, recruiting additional moderators where necessary.
-
-Operators of unofficial Go events and forums are encouraged to adopt this Code
-of Conduct, so that our community members enjoy a consistent experience across
-venues.
-
-## Open issues
-
-The Working Group does not yet include anyone from Asia, Europe, or Africa.
-In particular, Europe and China are home to a large swath of Go users, so it
-would be valuable to include some people from those areas in the working group.
+# Summary
+* Treat everyone with respect and kindness. 
+* Be thoughtful in how you communicate. 
+* Don’t be destructive or inflammatory. 
+* If you encounter an issue, please mail conduct@golang.org.


### PR DESCRIPTION
Just bringing it in line with the current code of conduct. The previous version referenced the ADG proposal and it's been through a few revisions - including a contact for issue resolution rather than a number of individuals who may or may not be involved in the project anymore.